### PR TITLE
demo - fix .env var update

### DIFF
--- a/src/demo/build.rs
+++ b/src/demo/build.rs
@@ -14,16 +14,18 @@ pub fn build_frontend(
     let env_file = demo_dir.join("app/frontend/.env");
     let mut env_content = fs::read_to_string(&env_file)?;
 
-    env_content = env_content
-        .replace(
-            "VITE_PROGRAM_PUBKEY=",
-            &format!("VITE_PROGRAM_PUBKEY={}", program_pubkey),
-        )
-        .replace(
-            "VITE_WALL_ACCOUNT_PUBKEY=",
-            &format!("VITE_WALL_ACCOUNT_PUBKEY={}", wall_pubkey),
-        )
-        .replace("VITE_NETWORK=", &format!("VITE_NETWORK={}", network));
+    env_content = Regex::new(r"VITE_PROGRAM_PUBKEY=.*")
+        .unwrap()
+        .replace(&env_content,&format!("VITE_PROGRAM_PUBKEY={}", program_pubkey))
+        .to_string();
+    env_content = Regex::new(r"VITE_WALL_ACCOUNT_PUBKEY=.*")
+        .unwrap()
+        .replace(&env_content,&format!("VITE_WALL_ACCOUNT_PUBKEY={}", wall_pubkey))
+        .to_string();
+    env_content = Regex::new(r"VITE_NETWORK=.*")
+        .unwrap()
+        .replace(&env_content, &format!("VITE_NETWORK={}", network))
+        .to_string();
 
     if let Some(url) = rpc_url {
         let re = Regex::new(r"VITE_RPC_URL=.*").unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3170,7 +3170,8 @@ pub async fn start_local_demo(args: &DemoStartArgs, config: &Config) -> Result<(
     // Write the graffiti_wall_state public key into the app/frontend/.env file
     let env_file = PathBuf::from(&demo_dir).join("app/frontend/.env");
     let mut env_content = fs::read_to_string(&env_file).context("Failed to read .env file")?;
-    env_content = env_content.replace("VITE_WALL_ACCOUNT_PUBKEY=", &format!("VITE_WALL_ACCOUNT_PUBKEY={}", graffiti_wall_state_pubkey));
+    let re = regex::Regex::new(r"VITE_WALL_ACCOUNT_PUBKEY=.*").unwrap();
+    env_content = re.replace(&env_content, format!("VITE_WALL_ACCOUNT_PUBKEY={}", graffiti_wall_state_pubkey)).to_string();
     fs::write(&env_file, env_content).context("Failed to write to .env file")?;
 
     // Stop existing demo containers


### PR DESCRIPTION
The issue arises when running `arch-cli demo start` for the second time.

If variables such as `VITE_WALL_ACCOUNT_PUBKEY=` are not empty, our config script will keep appending to the value instead of replacing it.

![Screenshot 2025-01-09 at 00 10 03](https://github.com/user-attachments/assets/b3089919-a0a2-4cd4-8fd9-60edde2ea1eb)
